### PR TITLE
Making aliases persistent

### DIFF
--- a/docs/day-two/quality-of-life-tweaks.md
+++ b/docs/day-two/quality-of-life-tweaks.md
@@ -13,6 +13,13 @@ alias dcp='docker-compose -f ~/docker-compose.yml '
 !!! info
     If you have a useful alias you think would benefit PMS users please submit a PR via GitHub for inclusion in this site following the format below. One alias or a group of related aliases showing example output.
 
+### Aliases in fish shell
+If fish shell is being used, aliases created using the `alias` command will not persist from one session to the next. In order to save an alias the `-s` or `--save` option must be used, refer to fish shell documentation: [alias - create a function](https://fishshell.com/docs/current/cmds/alias.html). Using the same example as above creating a persistent an alias in Fish looks like this:
+
+```fish
+alias -s dcp='docker-compose -f ~/docker-compose.yml '
+```
+
 ### Alias - Get container IPs
 
 * Credit: @quietsy - [Self-Hosted Discord](https://discord.gg/efhGsp75dx) server

--- a/docs/day-two/quality-of-life-tweaks.md
+++ b/docs/day-two/quality-of-life-tweaks.md
@@ -9,16 +9,20 @@ Bash aliases enable complex commands to be shortned to a few characters. For exa
 ```bash
 alias dcp='docker-compose -f ~/docker-compose.yml '
 ```
+### Making aliases persistent
 
+Aliases created by using `alias` command in the terminal will only be available for the current session. To make an alias persist across sessions it must be added the shell's initialization file. Here are some examples for popular shells:
+
+ - Bash: `~/.bashrc`, this is typically the default shell.
+ - ZSH: `~/.zshrc`
+ - Fish: `~/.config/fish/config.fish`
+
+For both Bash and ZSH simply add the desired aliases to the end of the file and reload the file using `. ~/.bashrc` or `. ~/.zshrc`.
+
+Fish is a bit different, the simplest way to save an alias in fish it to add the `-s` or `--save` option to the alias command in the terminal, this will add the alias in the correct format to the `config.fish` file. For example: `alias dcp='docker-compose -f ~/docker-compose.yml '`
+ 
 !!! info
     If you have a useful alias you think would benefit PMS users please submit a PR via GitHub for inclusion in this site following the format below. One alias or a group of related aliases showing example output.
-
-### Aliases in fish shell
-If fish shell is being used, aliases created using the `alias` command will not persist from one session to the next. In order to save an alias the `-s` or `--save` option must be used, refer to fish shell documentation: [alias - create a function](https://fishshell.com/docs/current/cmds/alias.html). Using the same example as above creating a persistent an alias in Fish looks like this:
-
-```fish
-alias -s dcp='docker-compose -f ~/docker-compose.yml '
-```
 
 ### Alias - Get container IPs
 

--- a/docs/day-two/quality-of-life-tweaks.md
+++ b/docs/day-two/quality-of-life-tweaks.md
@@ -16,10 +16,6 @@ Aliases created using the `alias` command in the terminal will only be available
  - Bash: `~/.bashrc`, this is typically the default shell.
  - ZSH: `~/.zshrc`
  - Fish: `~/.config/fish/config.fish`
-
-For both Bash and ZSH simply add the desired aliases to the end of the file and reload the file using `. ~/.bashrc` or `. ~/.zshrc`.
-
-Fish is a bit different, the simplest way to save an alias in fish it to add the `-s` or `--save` option to the alias command in the terminal, this will add the alias in the correct format to the `config.fish` file. For example: `alias -s dcp='docker-compose -f ~/docker-compose.yml '`
  
 !!! info
     If you have a useful alias you think would benefit PMS users please submit a PR via GitHub for inclusion in this site following the format below. One alias or a group of related aliases showing example output.

--- a/docs/day-two/quality-of-life-tweaks.md
+++ b/docs/day-two/quality-of-life-tweaks.md
@@ -11,7 +11,7 @@ alias dcp='docker-compose -f ~/docker-compose.yml '
 ```
 ### Making aliases persistent
 
-Aliases created by using `alias` command in the terminal will only be available for the current session. To make an alias persist across sessions it must be added the shell's initialization file. Here are some examples for popular shells:
+Aliases created using the `alias` command in the terminal will only be available for the current session. To make an alias persist across sessions it must be added the shell's initialization file. Here are some examples for popular shells:
 
  - Bash: `~/.bashrc`, this is typically the default shell.
  - ZSH: `~/.zshrc`
@@ -19,7 +19,7 @@ Aliases created by using `alias` command in the terminal will only be available 
 
 For both Bash and ZSH simply add the desired aliases to the end of the file and reload the file using `. ~/.bashrc` or `. ~/.zshrc`.
 
-Fish is a bit different, the simplest way to save an alias in fish it to add the `-s` or `--save` option to the alias command in the terminal, this will add the alias in the correct format to the `config.fish` file. For example: `alias dcp='docker-compose -f ~/docker-compose.yml '`
+Fish is a bit different, the simplest way to save an alias in fish it to add the `-s` or `--save` option to the alias command in the terminal, this will add the alias in the correct format to the `config.fish` file. For example: `alias -s dcp='docker-compose -f ~/docker-compose.yml '`
  
 !!! info
     If you have a useful alias you think would benefit PMS users please submit a PR via GitHub for inclusion in this site following the format below. One alias or a group of related aliases showing example output.


### PR DESCRIPTION
First, apologies if I have submitted two pull requests, I'm not a developer and this is my first time contributing to something that isn't my personal repository.

This is something I initially found confusing. I installed fish shell based on a recommendation online and didn't realize that the alias command behaves differently. It creates the alias just as bash would but only for the current session. I think that many newcomers that happen to have fish installed may become confused that when their aliases are gone the next session.

If you are interested it may be nice to add a section on fish shell here as I personally find it a great "quality of life tweak". If you are interested let me know and I can draft something up.