### PR TITLE
Fix command temporary mountpoint

### DIFF
--- a/docs/installation/manual-install.md
+++ b/docs/installation/manual-install.md
@@ -195,7 +195,7 @@ Move onto the next section 'Existing drive' to learn how to mount it (make it av
 You should now be able to mount the drive manually like so:
 
     mkdir /mnt/manualdiskmounttest
-    mount /dev/disk/by-id/ata-HGST_HDN728080ALE604_R6GPPDTY-part1
+    mount /dev/disk/by-id/ata-HGST_HDN728080ALE604_R6GPPDTY-part1 /mnt/manualdiskmounttest
 
 Verify that the drive mounted and displays the correct size as expected:
 


### PR DESCRIPTION
Thank you for all the effort in this Wiki. There is a tiny issue that may throw an inexperienced user during mount. I assume it worked during any other tests as the fstab is updated later. The placement of this command in the page is before fstab, so the mount fails. 

**Current command/behaviour**
```shell
philip@nas:~$ sudo mkdir /mnt/manualdiskmounttest
philip@nas:~$ sudo mount /dev/disk/by-id/scsi-XXXXX_XXXXXXXXXX_XXXXX-part1 
mount: /dev/disk/by-id/scsi-XXXXX_XXXXXXXXXX_XXXXX-part1: can't find in /etc/fstab.
philip@nas:~$
```

**Expected command/behaviour**
```shell
philip@nas:~$ sudo mkdir /mnt/manualdiskmounttest
philip@nas:~$ sudo mount /dev/disk/by-id/scsi-XXXXX_XXXXXXXXXX_XXXXX-part1 /mnt/manualdiskmounttest/
philip@nas:~$
philip@nas:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.9G     0  2.9G   0% /dev
tmpfs           595M  1.2M  594M   1% /run
/dev/vda2        25G  6.2G   18G  27% /
tmpfs           3.0G     0  3.0G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           3.0G     0  3.0G   0% /sys/fs/cgroup
/dev/loop0       55M   55M     0 100% /snap/core18/1880
/dev/loop1       72M   72M     0 100% /snap/lxd/16099
/dev/loop2       30M   30M     0 100% /snap/snapd/8542
tmpfs           595M     0  595M   0% /run/user/1000
/dev/sde1       9.1T   80M  8.6T   1% /mnt/manualdiskmounttest
philip@nas:~$ 
```

**System Info**
```
philip@nas:~$ cat /etc/os-release 
NAME="Ubuntu"
VERSION="20.04.1 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.1 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
philip@nas:~$ 
```

