### PR TITLE
Update manual-install.md with category.create flag on mergerfs fstab entry

### DIFF
--- a/docs/installation/manual-install.md
+++ b/docs/installation/manual-install.md
@@ -234,7 +234,7 @@ Here's what your `/etc/fstab` file might look like with 4 data disks and 1 SnapR
 /dev/disk/by-id/ata-WDC_WD100EMAZ-00WJTA0_2YJ15VJD-part1 /mnt/disk3   ext4 defaults 0 0
 /dev/disk/by-id/ata-HGST_HDN728080ALE604_R6GPPDTY-part1  /mnt/disk4   ext4 defaults 0 0
 
-/mnt/disk* /mnt/storage fuse.mergerfs defaults,nonempty,allow_other,use_ino,cache.files=off,moveonenospc=true,dropcacheonclose=true,minfreespace=200G,fsname=mergerfs 0 0
+/mnt/disk* /mnt/storage fuse.mergerfs defaults,nonempty,allow_other,use_ino,cache.files=off,moveonenospc=true,dropcacheonclose=true,category.create=mfs,minfreespace=200G,fsname=mergerfs 0 0
 ```
 
 Before you reboot, it's a good idea to check that everything mounted as you hoped. We can use `df -h` to verify this.


### PR DESCRIPTION
adding category.create=mfs option to mergerfs fstab entry so that it will write to the next disk once the first disk is full. 