### PR TITLE
Fixed link to snapraid exclude list

### DIFF
--- a/docs/installation/manual-install.md
+++ b/docs/installation/manual-install.md
@@ -320,7 +320,7 @@ exclude appdata/
 exclude *.!sync
 ```
 
-A full list of typical excludes can be found in GitHub [here](https://github.com/IronicBadger/infra/blob/master/group_vars/cartman.yaml#L719).
+A full list of typical excludes can be found in GitHub [here](https://github.com/IronicBadger/infra/blob/master/group_vars/morpheus.yaml#L747).
 
 ### Automating Parity Calculation
 


### PR DESCRIPTION
`cartman.yaml` doesn't exist anymore. Based on [last revision of file](https://github.com/IronicBadger/infra/blob/a00a94aba92f45ed495f1392510e58b4dc0fcccc/group_vars/cartman.yaml#L938) the list in `morpheus.yaml` is exactly the same