### PR TITLE
Add toggle for dark mode:

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,9 +12,16 @@ theme:
     repo: fontawesome/brands/github
     logo: fontawesome/regular/folder-open
   palette:
-    primary: blue
-    accent: teal
-    scheme: default
+    - scheme: default
+      primary: blue
+      accent: teal
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   font:
     code: Jet Brains Mono
   features:


### PR DESCRIPTION
Based on mkdocs documentation 'https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle'
I love the wiki and am working through it to try to create my own Perfect Media Server, but the lack of dark mode pains me. This is my first time working with `mkdocs`, so there were warnings when building locally (notably that the `google_analytics`: key is deprecated) which I ignored but perhaps they could be part of an enhanced P.R. 