### PR TITLE
Correct link to tagged blog posts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ![logo](images/assets/logo.png)
 
-Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://blog.linuxserver.io/tag/perfectmediaserver/). Those posts continue to be very popular but a blog post (or three) can only get you so far... 
+Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://www.linuxserver.io/blog/tag:perfectmediaserver#blog_list). Those posts continue to be very popular but a blog post (or three) can only get you so far... 
 
 I therefore introduce perfectmediaserver.com - a wiki format information repository detailing all you need to know to build a free, open and modular media server that will last for many, many years.
 


### PR DESCRIPTION
linuxserver.io "tagged posts" URL changed, was 404ing