### PR TITLE
Correct link to SnapRAID exclude example

### DIFF
--- a/docs/installation/manual-install.md
+++ b/docs/installation/manual-install.md
@@ -320,7 +320,7 @@ exclude appdata/
 exclude *.!sync
 ```
 
-A full list of typical excludes can be found in GitHub [here](https://github.com/IronicBadger/infra/blob/master/group_vars/morpheus.yaml#L747).
+A full list of typical excludes can be found in GitHub [here](https://github.com/IronicBadger/infra/blob/master/group_vars/morpheus.yaml#L52).
 
 ### Automating Parity Calculation
 


### PR DESCRIPTION
It goes to the wrong line number at the moment.