### PR TITLE
Update docker.md - remove podman `Stay a while..` - not DRY

### DIFF
--- a/docs/02-tech-stack/docker.md
+++ b/docs/02-tech-stack/docker.md
@@ -100,10 +100,6 @@ For an incredible list of inspiration, check out [awesome-selfhosted](https://gi
 
 See [podman](podman.md).
 
-!!! quote "Stay a while, and listen."
-    In March 2023, we released a podcast episode on this exact topic. Check it out for a more in-depth discussion.
-
-    <iframe src="https://player.fireside.fm/v2/dUlrHQih+fp1aR6Lw?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
 
 
 


### PR DESCRIPTION
This exact statement and iframe - `Stay a while, and listen...` - is repeated in the actual Podman section [here](https://github.com/ironicbadger/pms-wiki/blob/706f45665052054cf702f01fa3228ffd1828144e/docs/02-tech-stack/podman.md?plain=1#L3-L6) and thus need not re-mentioning in this section.

Plus, it confuses to have a "please see podman section" then immediately some content that tries to answer the question aswell, though in an incomplete fashion.

---

### ./docker/What about podman
![image](https://github.com/ironicbadger/pms-wiki/assets/7018928/eb122c3a-2e2e-41fb-bf4a-de8d85582625)


### ./podman
![image](https://github.com/ironicbadger/pms-wiki/assets/7018928/27b6c5d1-2c9f-49c4-92ac-dfe2348b7ccb)
