### PR TITLE
add badblocks and smartmontools to NixOS systemPackages in config.nix example

### DIFF
--- a/docs/02-tech-stack/nixos/configuration.nix.md
+++ b/docs/02-tech-stack/nixos/configuration.nix.md
@@ -55,6 +55,8 @@
     tree
     vim
     wget
+    smartmontools
+    e2fsprogs # badblocks
   ];
 
   networking = {


### PR DESCRIPTION
given the recommended [hard drive burn in rituals](https://perfectmediaserver.com/06-hardware/new-drive-burnin/#badblocks)... adding the required packages to the example `configuration.nix` to enable the hard drive burn in script to function, namely adding:

* e2fsprogs (for badblocks)
* smartmontools 