### PR TITLE
fixes, link kodi site and auto light/darkmode

### DIFF
--- a/docs/02-tech-stack/proxmox.md
+++ b/docs/02-tech-stack/proxmox.md
@@ -30,7 +30,7 @@ This means you get ZFS support out the box, a VM and LXC hosting platform with a
 !!! success "Proxmox is the right choice for you if:"
 
 
-    1. You like a stable base distro in debian
+    1. You like a stable base distro on debian
     2. You want to run Virtual Machines
     3. You want to run LXC containers
     4. You want to use ZFS

--- a/docs/03-installation/index.md
+++ b/docs/03-installation/index.md
@@ -23,7 +23,7 @@ This means you get ZFS support out the box, a VM and LXC hosting platform with a
 
 !!! success "Proxmox is the right choice for you if:"
 
-    1. You like a stable base distro in debian
+    1. You like a stable base distro on debian
     2. You want to run Virtual Machines
     3. You want to run LXC containers
     4. You want to use ZFS

--- a/docs/03-installation/manual-install-ubuntu.md
+++ b/docs/03-installation/manual-install-ubuntu.md
@@ -398,7 +398,7 @@ You can check the owner of a specific file or directory with `ls -la`.
 
 ## Network File Sharing
 
-A NAS or file server is no good without being able to access the data remotely. We're not talking about remotely like over the internet remotely here though, instead we're talking about other computers on your LAN. Raspberry Pis, Media Players (Kodi, for example), etc. You can find more information on remote file access over the internet in the [remote access](../04-day-two/remote-access/index.md) and [Top 10 Self-Hosted apps list](../04-day-two/top10apps.md#nextcloud).
+A NAS or file server is no good without being able to access the data remotely. We're not talking about remotely like over the internet remotely here though, instead we're talking about other computers on your LAN. Raspberry Pis, Media Players ([Kodi](https://kodi.tv), for example), etc. You can find more information on remote file access over the internet in the [remote access](../04-day-two/remote-access/index.md) and [Top 10 Self-Hosted apps list](../04-day-two/top10apps.md#nextcloud).
 
 There are two primary methods for sharing files over the network. Samba for Windows / Mac / Linux and NFS for Linux.
 

--- a/docs/04-day-two/top10apps.md
+++ b/docs/04-day-two/top10apps.md
@@ -160,6 +160,7 @@ There are a *lot* of options in this space - just take a look at [awesome-selfho
 * [Photoprism](https://github.com/photoprism/photoprism)
 * [Librephotos](https://github.com/LibrePhotos/librephotos)
 * [Piwigo](http://piwigo.org/)
+* [Immich](https://immich.app/)
 
 ## 10. Tiddlywiki
 

--- a/docs/05-advanced/passthrough-igpu-gvtg.md
+++ b/docs/05-advanced/passthrough-igpu-gvtg.md
@@ -95,7 +95,7 @@ GRUB_CMDLINE_LINUX_DEFAULT="quiet intel_iommu=on i915.enable_gvt=1 drm.debug=0"
 GRUB_CMDLINE_LINUX="biosdevname=0"
 ```
 
-Regenerate initramfs with update-initramfs -u -k all and reboot. To verify that mediated devices are now enabled take a look here:
+Regenerate initramfs with `update-initramfs -u -k all` and reboot. To verify that mediated devices are now enabled take a look here:
 
 ```
 root@unas:/home/alex# ls /sys/bus/pci/devices/0000\:00\:02.0/mdev_supported_types/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,14 +14,16 @@ theme:
     logo: fontawesome/regular/folder-open
   palette:
     # Palette toggle for light mode
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       primary: blue
       accent: teal
       toggle:
-        icon: material/brightness-7 
+        icon: material/brightness-7
         name: Switch to dark mode
     # Palette toggle for dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       accent: teal
       primary: deep orange
       toggle:


### PR DESCRIPTION
Hey I just discovered your nice documentation.

While reading I noticed the two typos and on further inspection I noticed some images are missing:
- https://github.com/ironicbadger/pms-wiki/blob/main/docs/06-hardware/intel-quicksync.md?plain=1#L11-L13
- https://github.com/ironicbadger/pms-wiki/blob/main/docs/06-hardware/hdd-purchase-methodology.md?plain=1#L43
- https://github.com/ironicbadger/pms-wiki/blob/main/docs/06-hardware/hdd-purchase-methodology.md?plain=1#L63

There is a non existend FAQ section refernced [here](https://github.com/ironicbadger/pms-wiki/blob/155e614f7ad252c87037f2fdd9dc53db2ba76b13/docs/03-installation/manual-install-ubuntu.md?plain=1#L23C157-L23C260)

Note Immich at the "top 10 apps" alternatives if that is allowed since it seems to be mentioned at [episode 79](https://selfhosted.show/79?t=1418) _(just discovered the podcast and therefore did not listen to it yet)_

And added the required config lines for mkdocs-material to consider the users system/browser preferences regarding light or dark (https://github.com/ironicbadger/pms-wiki/commit/236b64eb063710e1974abc7787d76e1c0c4cb062).

---

I currently have no mkdocs-material with me therefore not tested.

Greetings from 🇩🇪