### PR TITLE
fix: proxmox community script url

### DIFF
--- a/docs/03-installation/manual-install-proxmox.md
+++ b/docs/03-installation/manual-install-proxmox.md
@@ -42,7 +42,7 @@ Load up the community scripts website and look for `Proxmox VE tools -> Proxmox 
 From the Proxmox command line, execute:
 
 ```
-bash -c "$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/misc/post-pve-install.sh)"
+bash -c "$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/tools/pve/post-pve-install.sh)"
 ```
 
 Follow the prompts (defaults are good), reboot and continue here once complete. Feel free to run any other community helper scripts too - there's a lot of _great_ stuff over there.


### PR DESCRIPTION
The URL was dead as they changed it up a bit.

https://community-scripts.github.io/ProxmoxVE/scripts?id=post-pve-install