### PR TITLE
docs: fix broken blog.linuxserver.io link (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You can find the full site at [perfectmediaserver.com](https://perfectmediaserve
 
 ## Abstract
 
-Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://blog.linuxserver.io/tag/perfectmediaserver/). Those posts continue to be very popular, but a blog post can only get you so far. Therefore, I introduce perfectmediaserver.com - a wiki format information repository detailing all you need to know to build a free, open, and modular media server that will last for years to come.
+Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://www.linuxserver.io/blog). Those posts continue to be very popular, but a blog post can only get you so far. Therefore, I introduce perfectmediaserver.com - a wiki format information repository detailing all you need to know to build a free, open, and modular media server that will last for years to come.
 
 The primary technologies we recommend are [Linux](https://www.linux.org/), Containers (via [docker](https://www.docker.com/) and managed using [docker-compose](https://docs.docker.com/compose/)), [Proxmox](https://www.proxmox.com/en/), [mergerfs](https://github.com/trapexit/mergerfs/), [SnapRAID](http://www.snapraid.it/) and [ZFS](https://zfsonlinux.org/).
 


### PR DESCRIPTION
## Description

Fixed the broken link in README.md:
- **Old (404):** `https://blog.linuxserver.io/tag/perfectmediaserver/`
- **New (working):** `https://www.linuxserver.io/blog`

This was reported in #152 by the automated link checker.

## Changes
- Updated the broken blog series link to the current working URL

## Checklist
- [x] Link now returns 200 instead of 404
- [x] No other content changed

Fixes #152