### PR TITLE
Fix broken relative links in docs

### DIFF
--- a/docs/01-overview/nas-software-comparison.md
+++ b/docs/01-overview/nas-software-comparison.md
@@ -30,15 +30,15 @@ Coming soon ^TM^.
 [openmediavault](https://www.openmediavault.org/) is open-source, based around Debian and has been regularly updated for years. It is capable of providing every feature that PMS does *and* provides a webUI. The project does a lot of things right and is a notable contender in this comparison and is for the most part the work of one developer, votdev. Incredible stuff.
 
 <p align="center">
-<img alt="omv-github" src="../../images/screenshots/omv-github.png">
+<img alt="omv-github" src="../images/screenshots/omv-github.png">
 </p>
 
 That said, for a GUI to be worth learning it has to be meaningfully better than the alternative by reducing complexity or being eye-candy. Unfortunately, OMV fails on both fronts. Sadly the UI looks dated and each time I've tried to use the project over the years I've come away frustrated by the extra complexity it adds. 
 
 <p align="center">
-<img alt="omv-ui" src="../../images/screenshots/omv-ui.png">
+<img alt="omv-ui" src="../images/screenshots/omv-ui.png">
 </p>
 
 This pervasive frustration was also the case as a new user. Something that could be configured in a few lines of a config file required navigating a UI and doing a whole lot of clicking. As a more experienced administrator these days I have embraced automation via [Ansible](../05-advanced/infraascode.md#ansible) and can rebuild a server in 15 minutes from scratch. Managing a server entirely via the CLI might seem intimidating at first but it's really the way to go. Yes, even via mobile using JuiceSSH on Android or blink on iOS - see [remote access](../04-day-two/remote-access/index.md).
 
-OpenMediaVault is just Linux underneath though which is a good thing. This means it runs docker, supports ZFS (via DKMS), SnapRAID and mergerfs too. 
+OpenMediaVault is just Linux underneath though which is a good thing. This means it runs docker, supports ZFS (via DKMS), SnapRAID and mergerfs too.

--- a/docs/02-tech-stack/mergerfs.md
+++ b/docs/02-tech-stack/mergerfs.md
@@ -37,7 +37,7 @@ In the following diagram there are five separate disks. Each disk is a different
 
 ![mergerfs-blue](../images/tech-stack/mergerfs-blue.png)
 
-Configuration is performed via a single line of configuration in `/etc/fstab`[^1]. mergerfs has a lot knobs and dials to turn should you wish, they are all detailed in the [mergerfs-docs](trapexit.github.io/mergerfs).
+Configuration is performed via a single line of configuration in `/etc/fstab`[^1]. mergerfs has a lot knobs and dials to turn should you wish, they are all detailed in the [mergerfs-docs](https://trapexit.github.io/mergerfs).
 
 !!! example "An example `/etc/fstab` entry for mergerfs"
     ```

--- a/docs/02-tech-stack/snapraid.md
+++ b/docs/02-tech-stack/snapraid.md
@@ -11,7 +11,7 @@ You can use mergerfs without SnapRAID. And you can use SnapRAID without mergerfs
 For most PMS deployments, your media will be spread across a handful of JBOD drives merged together with [mergerfs](mergerfs.md). Without SnapRAID if a drive were to fail, you'd instantly lose all data on the failed drive forever. With SnapRAID you're able to rebuild that failed drive using parity data from your last snapshot. This approach is uniquely well suited to large, static datasets like media libraries. It is not well suited to fast moving data like your Plex metadata for example.
 
 <p align="center">
-<img alt="mergerfs-snapraid-diagram" src="../../images/tech-stack/diagram-mergerfs-snapraid.png" width="525">
+<img alt="mergerfs-snapraid-diagram" src="../images/tech-stack/diagram-mergerfs-snapraid.png" width="525">
 </p>
 
 ## What is SnapRAID?

--- a/docs/02-tech-stack/zfs.md
+++ b/docs/02-tech-stack/zfs.md
@@ -22,7 +22,7 @@ Jim Salter wrote a [ZFS 101](https://arstechnica.com/information-technology/2020
 Simply put, ZFS is the gold standard for storing data. You must pay attention when creating a ZFS vdev due to the lack of flexibility on offer[^1]. This is [due to change](https://twitter.com/mahrens1/status/1338876011161690112?s=20) with the *eventual* inclusion of RAIDZ expansion <s>but at the time of writing this feature is not available</s> which became available on 14 January 2025 with the release of version 2.3.0.
 
 <p align=center>
-<img src="../../images/tech-stack/zfs-raidz-tweet.png">
+<img src="../images/tech-stack/zfs-raidz-tweet.png">
 </p>
 
 ## Why use ZFS for PMS?

--- a/docs/04-day-two/top10apps.md
+++ b/docs/04-day-two/top10apps.md
@@ -16,7 +16,7 @@ My YouTube channel - [KTZ Systems](https://www.youtube.com/@ktzsystems) - is sti
 [Jellyfin](https://jellyfin.org/) is the media solution that puts you in control of your media. Stream to any device from your own server, with no strings attached. Your media, your server, your way.
 
 <p align="center">
-<img alt="jellyfin-banner" src="../../images/top10/jellyfin.png">
+<img alt="jellyfin-banner" src="../images/top10/jellyfin.png">
 </p>
 
 Jellyfin serves no business model, and is not subject to the gradual enshitification that we've seen with Plex over the years. With no cloud connectivity required for authentication, no random streaming services and snappy performance - a fully featured, local first media server experience awaits. Did I mention that it's completely open source too?
@@ -66,7 +66,7 @@ Immich recently [joined FUTO](https://immich.app/blog/2024/immich-core-team-goes
 Surely this pick needs no introduction. Think of Nextcloud somewhat like your own personal Dropbox replacement. Although, that is doing it a disservice because Nextcloud supports *many* more features than Dropbox. Nextcloud provide a [demo](https://try.nextcloud.com) if you'd like to try before you "buy" (Nextcloud is free).
 
 <p align="center">
-<img alt="nextcloud-banner" src="../../images/top10/nextcloud-banner.png">
+<img alt="nextcloud-banner" src="../images/top10/nextcloud-banner.png">
 </p>
 
 It can be a bit unreliable and unwieldy to administer at times - especially around update cycles. But once you get a working configuration it's a really handy tool.

--- a/docs/06-hardware/cases.md
+++ b/docs/06-hardware/cases.md
@@ -61,7 +61,7 @@ The Fractal Define R5 is a classic example of "if it ain't broke, don't fix it".
 
 <figure markdown>
 ![alexs-uk-server](../images/hardware/cases/define-r5.jpg){: width=700 }
-<figcaption>This is Alex's old server from before he emigrated to the USA. It lives in the UK as his primary off-site <a href="../../04-day-two/backups/">backup</a> system.</figcaption>
+<figcaption>This is Alex's old server from before he emigrated to the USA. It lives in the UK as his primary off-site <a href="../04-day-two/backups/">backup</a> system.</figcaption>
 </figure>
 
 * Motherboard Form Factor - Mini-ITX, mATX, ATX

--- a/docs/blog/posts/2024/20241130-update.md
+++ b/docs/blog/posts/2024/20241130-update.md
@@ -7,7 +7,7 @@ categories:
 readtime: 2
 ---
 
-A quick update post today. The X13SAE-F, Intel i5 13600k build has bedded in quite nicely over the last 6 months. Check out the full details over on the [example builds](../../01-overview/alexs-example-builds) for the exact hardware used.
+A quick update post today. The X13SAE-F, Intel i5 13600k build has bedded in quite nicely over the last 6 months. Check out the full details over on the [example builds](../../../01-overview/alexs-example-builds) for the exact hardware used.
 
 Besides a minor hiccup with the way Intel handled [some QC issues](https://www.youtube.com/watch?v=OVdmK1UGzGs), the chip has performed very well.
 


### PR DESCRIPTION
## Summary\n- fix several image links that incorrectly resolved outside the docs tree\n- add the missing scheme to the mergerfs docs URL\n- fix relative links to the backups and example builds pages\n\n## Checks\n- git diff --check\n- verified updated repository-relative targets with git ls-tree\n\nFixes #144