### PR TITLE
[codex] Fix broken link reports

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -51,6 +51,7 @@ jobs:
             --exclude "forum.asrock.com"
             --exclude "forums.unraid.net"
             --exclude "namecheap.com"
+            --exclude "nixos.org"
             --exclude "ubuntu.com"
             --exclude "pcpartpicker.com"
             --exclude "supermicro.com"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -27,6 +27,7 @@ jobs:
             --accept=200,201,202,203,204,301,302,303,307,308
             --timeout 20
             --max-retries 3
+            --root-dir docs
             --user-agent "Mozilla/5.0 (compatible; pms-wiki-link-checker)"
             --exclude-private
             --exclude "^(?i:mailto)"
@@ -39,8 +40,19 @@ jobs:
             --exclude "example.org"
             --exclude "plausible.ktz.cloud"
             --exclude "techhub.social"
+            --exclude "linkedin.com"
             --exclude "reddit.com"
             --exclude "www.reddit.com"
+            --exclude "ark.intel.com"
+            --exclude "connection.com"
+            --exclude "corsair.com"
+            --exclude "ebay.com"
+            --exclude "forum.asrock.com"
+            --exclude "forums.unraid.net"
+            --exclude "namecheap.com"
+            --exclude "ubuntu.com"
+            --exclude "pcpartpicker.com"
+            --exclude "supermicro.com"
             --exclude-path node_modules/
             --exclude-path .git/
             '**/*.md'
@@ -71,21 +83,27 @@ jobs:
             let currentFile = '';
             
             for (const line of lines) {
-              // Match file paths in the report
-              if (line.includes('.md') && !line.includes('|')) {
-                currentFile = line.trim().replace(/^\*\*/, '').replace(/\*\*$/, '');
+              const sectionMatch = line.match(/^### Errors in (.+\.md)$/);
+              if (sectionMatch) {
+                currentFile = sectionMatch[1];
+                continue;
               }
-              // Match broken links
-              if (line.includes('[') && line.includes('](') && line.includes('Failed')) {
-                const match = line.match(/\[.*?\]\((.*?)\)/);
-                if (match) {
-                  brokenLinks.push({
-                    file: currentFile,
-                    url: match[1],
-                    line: line.trim()
-                  });
-                }
+
+              const errorMatch = line.match(/^\* \[([^\]]+)\] <([^>]+)> \| (.+)$/);
+              if (errorMatch) {
+                brokenLinks.push({
+                  file: currentFile,
+                  status: errorMatch[1],
+                  url: errorMatch[2],
+                  detail: errorMatch[3],
+                  line: line.trim()
+                });
               }
+            }
+
+            if (brokenLinks.length === 0) {
+              core.warning('Lychee failed, but no broken links were parsed from lychee-report.md; skipping issue creation.');
+              return;
             }
             
             const issueBody = `## Broken Links Detected
@@ -103,7 +121,9 @@ jobs:
             
             ${brokenLinks.map((link, index) => 
               `${index + 1}. **File:** \`${link.file}\`
+               **Status:** ${link.status}
                **Broken URL:** ${link.url}
+               **Details:** ${link.detail}
                **Action:** Find this URL in the file and update or remove it
             `).join('\n')}
             

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -43,6 +43,7 @@ jobs:
             --exclude "linkedin.com"
             --exclude "reddit.com"
             --exclude "www.reddit.com"
+            --exclude "arstechnica.com"
             --exclude "ark.intel.com"
             --exclude "connection.com"
             --exclude "corsair.com"

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -32,12 +32,7 @@ jobs:
       - name: Install MkDocs and dependencies
         run: |
           pip install --upgrade pip
-          pip install mkdocs-material
-          pip install mkdocs-material[imaging]
-          pip install mkdocs-minify-plugin
-          pip install mkdocs-git-revision-date-plugin
-          pip install mkdocs-material-plausible-plugin
-          pip install pillow cairosvg
+          pip install -r requirements.txt
           
       - name: Build MkDocs site
         run: mkdocs build --strict --verbose

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You can find the full site at [perfectmediaserver.com](https://perfectmediaserve
 
 ## Abstract
 
-Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://blog.linuxserver.io/tag/perfectmediaserver/). Those posts continue to be very popular, but a blog post can only get you so far. Therefore, I introduce perfectmediaserver.com - a wiki format information repository detailing all you need to know to build a free, open, and modular media server that will last for years to come.
+Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://www.linuxserver.io/blog/tag:perfectmediaserver). Those posts continue to be very popular, but a blog post can only get you so far. Therefore, I introduce perfectmediaserver.com - a wiki format information repository detailing all you need to know to build a free, open, and modular media server that will last for years to come.
 
 The primary technologies we recommend are [Linux](https://www.linux.org/), Containers (via [docker](https://www.docker.com/) and managed using [docker-compose](https://docs.docker.com/compose/)), [Proxmox](https://www.proxmox.com/en/), [mergerfs](https://github.com/trapexit/mergerfs/), [SnapRAID](http://www.snapraid.it/) and [ZFS](https://zfsonlinux.org/).
 

--- a/docs/01-overview/nas-software-comparison.md
+++ b/docs/01-overview/nas-software-comparison.md
@@ -30,15 +30,15 @@ Coming soon ^TM^.
 [openmediavault](https://www.openmediavault.org/) is open-source, based around Debian and has been regularly updated for years. It is capable of providing every feature that PMS does *and* provides a webUI. The project does a lot of things right and is a notable contender in this comparison and is for the most part the work of one developer, votdev. Incredible stuff.
 
 <p align="center">
-<img alt="omv-github" src="../../images/screenshots/omv-github.png">
+<img alt="omv-github" src="../images/screenshots/omv-github.png">
 </p>
 
 That said, for a GUI to be worth learning it has to be meaningfully better than the alternative by reducing complexity or being eye-candy. Unfortunately, OMV fails on both fronts. Sadly the UI looks dated and each time I've tried to use the project over the years I've come away frustrated by the extra complexity it adds. 
 
 <p align="center">
-<img alt="omv-ui" src="../../images/screenshots/omv-ui.png">
+<img alt="omv-ui" src="../images/screenshots/omv-ui.png">
 </p>
 
 This pervasive frustration was also the case as a new user. Something that could be configured in a few lines of a config file required navigating a UI and doing a whole lot of clicking. As a more experienced administrator these days I have embraced automation via [Ansible](../05-advanced/infraascode.md#ansible) and can rebuild a server in 15 minutes from scratch. Managing a server entirely via the CLI might seem intimidating at first but it's really the way to go. Yes, even via mobile using JuiceSSH on Android or blink on iOS - see [remote access](../04-day-two/remote-access/index.md).
 
-OpenMediaVault is just Linux underneath though which is a good thing. This means it runs docker, supports ZFS (via DKMS), SnapRAID and mergerfs too. 
+OpenMediaVault is just Linux underneath though which is a good thing. This means it runs docker, supports ZFS (via DKMS), SnapRAID and mergerfs too.

--- a/docs/02-tech-stack/mergerfs.md
+++ b/docs/02-tech-stack/mergerfs.md
@@ -37,7 +37,7 @@ In the following diagram there are five separate disks. Each disk is a different
 
 ![mergerfs-blue](../images/tech-stack/mergerfs-blue.png)
 
-Configuration is performed via a single line of configuration in `/etc/fstab`[^1]. mergerfs has a lot knobs and dials to turn should you wish, they are all detailed in the [mergerfs-docs](trapexit.github.io/mergerfs).
+Configuration is performed via a single line of configuration in `/etc/fstab`[^1]. mergerfs has a lot knobs and dials to turn should you wish, they are all detailed in the [mergerfs-docs](https://trapexit.github.io/mergerfs/latest/).
 
 !!! example "An example `/etc/fstab` entry for mergerfs"
     ```

--- a/docs/02-tech-stack/snapraid.md
+++ b/docs/02-tech-stack/snapraid.md
@@ -11,7 +11,7 @@ You can use mergerfs without SnapRAID. And you can use SnapRAID without mergerfs
 For most PMS deployments, your media will be spread across a handful of JBOD drives merged together with [mergerfs](mergerfs.md). Without SnapRAID if a drive were to fail, you'd instantly lose all data on the failed drive forever. With SnapRAID you're able to rebuild that failed drive using parity data from your last snapshot. This approach is uniquely well suited to large, static datasets like media libraries. It is not well suited to fast moving data like your Plex metadata for example.
 
 <p align="center">
-<img alt="mergerfs-snapraid-diagram" src="../../images/tech-stack/diagram-mergerfs-snapraid.png" width="525">
+<img alt="mergerfs-snapraid-diagram" src="../images/tech-stack/diagram-mergerfs-snapraid.png" width="525">
 </p>
 
 ## What is SnapRAID?

--- a/docs/02-tech-stack/zfs.md
+++ b/docs/02-tech-stack/zfs.md
@@ -22,7 +22,7 @@ Jim Salter wrote a [ZFS 101](https://arstechnica.com/information-technology/2020
 Simply put, ZFS is the gold standard for storing data. You must pay attention when creating a ZFS vdev due to the lack of flexibility on offer[^1]. This is [due to change](https://twitter.com/mahrens1/status/1338876011161690112?s=20) with the *eventual* inclusion of RAIDZ expansion <s>but at the time of writing this feature is not available</s> which became available on 14 January 2025 with the release of version 2.3.0.
 
 <p align=center>
-<img src="../../images/tech-stack/zfs-raidz-tweet.png">
+<img src="../images/tech-stack/zfs-raidz-tweet.png">
 </p>
 
 ## Why use ZFS for PMS?

--- a/docs/04-day-two/top10apps.md
+++ b/docs/04-day-two/top10apps.md
@@ -16,7 +16,7 @@ My YouTube channel - [KTZ Systems](https://www.youtube.com/@ktzsystems) - is sti
 [Jellyfin](https://jellyfin.org/) is the media solution that puts you in control of your media. Stream to any device from your own server, with no strings attached. Your media, your server, your way.
 
 <p align="center">
-<img alt="jellyfin-banner" src="../../images/top10/jellyfin.png">
+<img alt="jellyfin-banner" src="../images/top10/jellyfin.png">
 </p>
 
 Jellyfin serves no business model, and is not subject to the gradual enshitification that we've seen with Plex over the years. With no cloud connectivity required for authentication, no random streaming services and snappy performance - a fully featured, local first media server experience awaits. Did I mention that it's completely open source too?
@@ -66,7 +66,7 @@ Immich recently [joined FUTO](https://immich.app/blog/2024/immich-core-team-goes
 Surely this pick needs no introduction. Think of Nextcloud somewhat like your own personal Dropbox replacement. Although, that is doing it a disservice because Nextcloud supports *many* more features than Dropbox. Nextcloud provide a [demo](https://try.nextcloud.com) if you'd like to try before you "buy" (Nextcloud is free).
 
 <p align="center">
-<img alt="nextcloud-banner" src="../../images/top10/nextcloud-banner.png">
+<img alt="nextcloud-banner" src="../images/top10/nextcloud-banner.png">
 </p>
 
 It can be a bit unreliable and unwieldy to administer at times - especially around update cycles. But once you get a working configuration it's a really handy tool.

--- a/docs/06-hardware/cases.md
+++ b/docs/06-hardware/cases.md
@@ -61,7 +61,7 @@ The Fractal Define R5 is a classic example of "if it ain't broke, don't fix it".
 
 <figure markdown>
 ![alexs-uk-server](../images/hardware/cases/define-r5.jpg){: width=700 }
-<figcaption>This is Alex's old server from before he emigrated to the USA. It lives in the UK as his primary off-site <a href="../../04-day-two/backups/">backup</a> system.</figcaption>
+<figcaption>This is Alex's old server from before he emigrated to the USA. It lives in the UK as his primary off-site <a href="../04-day-two/backups/">backup</a> system.</figcaption>
 </figure>
 
 * Motherboard Form Factor - Mini-ITX, mATX, ATX
@@ -84,7 +84,7 @@ Overall, it's an extremely solid option for anyone looking to build a PMS system
 
 ## Fractal Node Series
 
-> Review contributed by [Hogcycle](https://github.com/hogcycle)
+> Review contributed by Hogcycle
 
 The Fractal Design Node 804 was released in 2014 and is a solid contender for a Perfect Media Server. A major distinction and benefit is how this case is split down the middle into two chambers. 
 

--- a/docs/06-hardware/cases.md
+++ b/docs/06-hardware/cases.md
@@ -61,7 +61,7 @@ The Fractal Define R5 is a classic example of "if it ain't broke, don't fix it".
 
 <figure markdown>
 ![alexs-uk-server](../images/hardware/cases/define-r5.jpg){: width=700 }
-<figcaption>This is Alex's old server from before he emigrated to the USA. It lives in the UK as his primary off-site <a href="../04-day-two/backups/">backup</a> system.</figcaption>
+<figcaption>This is Alex's old server from before he emigrated to the USA. It lives in the UK as his primary off-site <a href="../04-day-two/backups.md">backup</a> system.</figcaption>
 </figure>
 
 * Motherboard Form Factor - Mini-ITX, mATX, ATX

--- a/docs/06-hardware/hdd-purchase-methodology.md
+++ b/docs/06-hardware/hdd-purchase-methodology.md
@@ -40,8 +40,6 @@ Rule #3 is obvious. Don't buy naked drives from Amazon. I have twice due to comp
 
 I never even bothered trying to power that one up. It was returned immediately. Save yourself the hassle and don't buy drives from Amazon.
 
-<img src="../../images/naked-drive.jpg" align="center">
-
 These rules happen to tie in nicely (surprise!) with some of my other overall thoughts on putting together the perfect media server and a topic I covered in the 2016 article. Namely, home users (the primary target for this series) probably don't want to have to buy 3+ drives at a time - it's just too much money to spend in one go! The ability to organically grow a system as your content collection, drone footage or linux ISO stash does is an absolutely core tenet and a key reason why I don't think any solution which requires adding more than one drive at once (going full ZFS, for example) is a suitable solution for most people, most of the time. By growing the system organically you not only put less pressure on your budget up front but you also potentially increase the overall reliability of the system thanks to Rule #1 and Rule #2.
 
 If you needed another reason; the longer you wait, the more TBs you'll get for the same cash. 2 years ago I tried to 'standardise' on 6TB drives. The time came 6 months ago when I wanted to add another drive to my system and for the same money per drive I could now furnish my system with an 8TB model. Backblaze, purveyors of the excellent ["Annual failure rate"](https://www.backblaze.com/b2/hard-drive-test-data.html) series, have [this interesting take](https://www.backblaze.com/blog/hard-drive-cost-per-gigabyte/) on cost per gigabyte.
@@ -59,9 +57,4 @@ I'll keep this section brief as there is a load of information readily available
 
 You might find yourself needing to either modify your power cables to get around the 3.3v detection fix on WD drives. WD obviously want you paying top dollar for your drives and so have enabled in the firmware a 3.3v detection dead mans switch. The fix is easy. Either A) apply kapton tape to the pins - [detailed here](https://www.reddit.com/r/DataHoarder/comments/7g2v9o/33v_pin_reset_directions_d) or B) cut the 3.3v wire on your sata connectors. Not all PSUs are affected and it's really not a big deal. See below, I made some custom power cables which omit the 3.3v rail altogether - problem solved.
 
-<p align="center">
-<img src="../../images/custom-power-cable.png">
-</p>
-
 In late 2018 I purchased 2 WD Easystores from Best Buy and 2 8TB Seagate SMR shingled drives from Amazon and so far they perform identically to their more expensive brethren. You have nothing to fear here except the lack of warranty - but for the price I'll take it.
-

--- a/docs/06-hardware/intel-quicksync.md
+++ b/docs/06-hardware/intel-quicksync.md
@@ -9,7 +9,7 @@ Quick Sync (QSV) has been a game changing technology. It is a hardware media enc
 Best is of course a subjective term. But over the first half over 2024, Alex and a big chunk of the self-hosting community ran hundreds of CPU tests to benchmark QSV in the first public test of its type. For full thoughts, see the [blog post](https://blog.ktz.me/the-best-media-server-cpu-in-the-world/).
 
 <p align="center">
-<img alt="igputop" src="../../images/hardware/igpu-cpu-graph.png">
+<img alt="igputop" src="../images/hardware/igpu-cpu-graph.png">
 </p>
 
 ## Performance

--- a/docs/blog/posts/2024/20241130-update.md
+++ b/docs/blog/posts/2024/20241130-update.md
@@ -7,7 +7,7 @@ categories:
 readtime: 2
 ---
 
-A quick update post today. The X13SAE-F, Intel i5 13600k build has bedded in quite nicely over the last 6 months. Check out the full details over on the [example builds](../../01-overview/alexs-example-builds) for the exact hardware used.
+A quick update post today. The X13SAE-F, Intel i5 13600k build has bedded in quite nicely over the last 6 months. Check out the full details over on the [example builds](../../../01-overview/alexs-example-builds.md) for the exact hardware used.
 
 Besides a minor hiccup with the way Intel handled [some QC issues](https://www.youtube.com/watch?v=OVdmK1UGzGs), the chip has performed very well.
 


### PR DESCRIPTION
## Summary

Fix the broken-link cleanup surfaced by the automated `broken-links` issues and prevent the workflow from opening malformed zero-count reports.

## Root Cause

The scheduled lychee workflow failed correctly, but the GitHub Script parser only looked for Markdown-link-shaped lines containing `Failed`. Lychee's Markdown report emits errors as lines like `* [404] <url> | details`, so the workflow created issues titled `Fix 0 broken link(s) in documentation` even when the full report contained real errors.

## Changes

- Parse lychee Markdown error lines in `.github/workflows/check-links.yml` and include status/details in generated issues.
- Skip issue creation when lychee fails but no errors are parsed.
- Set `--root-dir docs` so root-relative docs assets resolve correctly.
- Exclude known bot-blocked/flaky domains from automated link checking.
- Fix local documentation links and image paths found in the reports.
- Remove references to missing image assets and dead profile/tag links.

## Validation

- `git diff --check`
- focused local Markdown/HTML link resolver: all local links resolve
- `/tmp/pms-wiki-venv/bin/mkdocs build --strict`
- Verified no open `broken-links` issues remain after triage.