### PR TITLE
fix: update broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The primary technologies we recommend are [Linux](https://www.linux.org/), Conta
 
 You can find the original blog series of PMS here:
 
-- [Perfect Media Server (2016 Edition) - The Original Article](https://blog.linuxserver.io/2016/02/02/the-perfect-media-server-2016/)
-- [Perfect Media Server (2017 Edition) - Extensive video guides](https://blog.linuxserver.io/2017/06/24/the-perfect-media-server-2017/)
-- [Perfect Media Server (2019 Edition) - Boring is reliable + adding ZFS](https://blog.linuxserver.io/2019/07/16/perfect-media-server-2019/)
+- [Perfect Media Server (2016 Edition) - The Original Article](https://www.linuxserver.io/blog/2016-02-02-the-perfect-media-server-2016)
+- [Perfect Media Server (2017 Edition) - Extensive video guides](https://www.linuxserver.io/blog/2017-06-24-the-perfect-media-server-2017)
+- [Perfect Media Server (2019 Edition) - Boring is reliable + adding ZFS](https://www.linuxserver.io/blog/2019-07-16-perfect-media-server-2019)
 - [Perfect Media Server (2020 Edition) - Launching perfectmediaserver.com](https://blog.ktz.me/the-perfect-media-server-2020-edition/)
 
 If you're looking to build a media server, then you've come to the right place. This site documents the many aspects of building a media server using Free and Open Source Software wherever possible.

--- a/docs/01-overview/alexs-example-builds.md
+++ b/docs/01-overview/alexs-example-builds.md
@@ -116,7 +116,7 @@ Here's a high level overview snapshot of my PMS implementation as it stands righ
     | [Traefik](https://traefik.io/)                   | Reverse proxy                              | [Traefik 101 Guide](../04-day-two/remote-access/traefik101.md)              |
     | [Authelia](https://www.authelia.com/)            | Basic auth frontend                        |                                                                  |
     | [Flame](https://github.com/pawelmalak/flame)     | Dashboard                                  |                                                                  |
-    | [Plex](https://www.plex.tv/)                     | Media server                               | [Top 10 Apps - Plex](../04-day-two/top10apps.md)             |
+    | [Plex](https://watch.plex.tv/)                     | Media server                               | [Top 10 Apps - Plex](../04-day-two/top10apps.md)             |
     | [Tautulli](https://github.com/Tautulli/Tautulli) | Plex analytics                             |                                                                  |
     | [Nextcloud](https://nextcloud.com/)              | An awesome self-hosted dropbox alternative | [Top 10 Apps - Nextcloud](../04-day-two/top10apps.md#2-nextcloud)        |
     | [Smokeping](https://oss.oetiker.ch/smokeping/)   | Latency measurement and graphing tool      | [Top 10 Apps - Smokeping](../04-day-two/top10apps.md#6-smokeping)   |

--- a/docs/01-overview/index.md
+++ b/docs/01-overview/index.md
@@ -42,11 +42,11 @@ On top of that, the software used is all open source which means you'll never be
 
 You've already found your way to this site so you're in a good spot. Organising so much information has been a labour of love for several months but a good place to start would be familiarising yourself with the primary tech stack components before moving onto the installation section.
 
-We cover some hardware topics here as well but you might want to go and check out my friends over at [serverbuilds.net](https://serverbuilds.net) for some interesting, low cost ideas in that department.
+We cover some hardware topics here as well but you might want to go and check out my friends over at [serverbuilds.net](https://www.serverbuilds.net) for some interesting, low cost ideas in that department.
 
 Beyond that go ahead and make extensive use of the search feature which can be invoked with `/`, just like in Vim.
 
-You can find me on the [Self-Hosted podcast Discord server](https://discord.gg/efhGsp75dx) or [Twitter](https://twitter.com/ironicbadger) where I'm @IronicBadger if you have questions, concerns or feedback about the site. Please also consider contributing [via PR](https://github.com/IronicBadger/pms-wiki/) if you find something that needs fixing.
+You can find me on the [Self-Hosted podcast Discord server](https://discord.com/invite/efhGsp75dx) or [Twitter](https://twitter.com/ironicbadger) where I'm @IronicBadger if you have questions, concerns or feedback about the site. Please also consider contributing [via PR](https://github.com/IronicBadger/pms-wiki/) if you find something that needs fixing.
 
 ## Why did you write this?
 

--- a/docs/02-tech-stack/docker.md
+++ b/docs/02-tech-stack/docker.md
@@ -1,6 +1,6 @@
 # Docker
 
-Back in 2016 when I wrote the [original](https://blog.linuxserver.io/2016/02/02/the-perfect-media-server-2016/) PMS article docker was fairly new. Fast forward 8(!) years and containerisation has cemented itself as a major force in the industry.
+Back in 2016 when I wrote the [original](https://www.linuxserver.io/blog/2016-02-02-the-perfect-media-server-2016) PMS article docker was fairly new. Fast forward 8(!) years and containerisation has cemented itself as a major force in the industry.
 
 For those looking to build a media server, containers offer a uniquely brilliant way to run applications. They divorce the running application from its data whilst making managing their persistent data and configuration simple.
 
@@ -71,9 +71,9 @@ Docker were first to market and hijacked the root namespace when you execute a `
 Some other notable registries include, but are not limited to:
 
 * [Quay.io](https://quay.io/)
-* [GitHub Container Registry](https://github.com/features/packages)
+* [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 
-I might be biased due to my prior involvement with the project but [LinuxServer.io](https://linuxserver.io) make the largest collection of media server type containers on the internet. At the time of writing their containers have seen over 14 billion pulls and you can find a [full list of available LinuxServer.io apps](https://fleet.linuxserver.io/).
+I might be biased due to my prior involvement with the project but [LinuxServer.io](https://www.linuxserver.io) make the largest collection of media server type containers on the internet. At the time of writing their containers have seen over 14 billion pulls and you can find a [full list of available LinuxServer.io apps](https://www.linuxserver.io/our-images).
 
 ## How do I pick one container over another?
 
@@ -81,7 +81,7 @@ It's a common question I see, and a valid one.
 
 <div class="reddit-embed" data-embed-media="www.redditmedia.com" data-embed-parent="false" data-embed-live="false" data-embed-uuid="ab15371c-d825-4747-ab1b-1451c2d8b65e" data-embed-created="2020-12-28T01:30:18.316Z"><a href="https://www.reddit.com/r/selfhosted/comments/kece3p/intels_quick_sync_is_a_total_game_changer_im_a/gg4oerh/">Comment</a> from discussion <a href="https://www.reddit.com/r/selfhosted/comments/kece3p/intels_quick_sync_is_a_total_game_changer_im_a/">Intel&#x27;s Quick Sync is a total game changer - I&#x27;m a little late to the party but here&#x27;s a post on how I set it up with Proxmox, Plex and Blue Iris using Intel GVT-g (virtual GPUs)</a>.</div><script async src="https://www.redditstatic.com/comment-embed.js"></script>
 
-The first place I always check is LinuxServer's [Fleet](https://fleet.linuxserver.io/) list of images - if an LSIO image exists, job done. I'll always pick LSIO images first because of:
+The first place I always check is LinuxServer's [Fleet](https://www.linuxserver.io/our-images) list of images - if an LSIO image exists, job done. I'll always pick LSIO images first because of:
 
 * Easy user mappings via `PGID` and `PUID`
 * Regular security and application updates
@@ -104,5 +104,5 @@ For an incredible list of inspiration, check out [awesome-selfhosted](https://gi
 
 See [podman](podman.md).
 
-[^1]: [Docker Volumes explained - docs.docker.com/storage/volumes](https://docs.docker.com/storage/volumes/)
+[^1]: [Docker Volumes explained - docs.docker.com/engine/storage/volumes](https://docs.docker.com/engine/storage/volumes/)
 [^2]: [docker-compose - docs.docker.com/compose](https://docs.docker.com/compose/)

--- a/docs/02-tech-stack/mergerfs.md
+++ b/docs/02-tech-stack/mergerfs.md
@@ -71,7 +71,7 @@ Here are the key features of mergerfs that make it perfect for PMS:
     * Drives may contain data when mounted via Mergerfs
 * Simple configuration with one line in `/etc/fstab`
 
-For the home user the incremental addition of hard drives is a very important consideration. ZFS still lacks easy expandability and for most people, adding 4 or more drives at once is prohibitively expensive - see ["The hidden cost of ZFS"](http://louwrentius.com/the-hidden-cost-of-using-zfs-for-your-home-nas.html).
+For the home user the incremental addition of hard drives is a very important consideration. ZFS still lacks easy expandability and for most people, adding 4 or more drives at once is prohibitively expensive - see ["The hidden cost of ZFS"](https://louwrentius.com/the-hidden-cost-of-using-zfs-for-your-home-nas.html).
 
 Drives of a useful capacity cost upwards of $150 (x4 = $600). $600 is a chunk of change to plop down in one go just because you filled up your last drive - why not have a system that grows as your needs do?
 

--- a/docs/02-tech-stack/nixos.md
+++ b/docs/02-tech-stack/nixos.md
@@ -121,7 +121,7 @@ So if the beautiful single-file simplicity isn't the future and Flakes are, then
 
 Remember how Nix is a package manager? Well, that means we can use Nix and a related tool called [Home Manager](https://github.com/nix-community/home-manager) to manage these configurations, declaratively, across multiple architectures and OSs. If you don't think that's cool, then you probably have your answer about whether NixOS is for you or not!
 
-``` nix title='Excerpt from <a href="https://github.com/ironicbadger/nix-testing/blob/main/flake.nix" target="_blank">github.com/ironicbadger/nix-testing/flake.nix</a> that shows configuring macOS alongside nixOS in the same file.'
+``` nix title='Excerpt from <a href="https://github.com/ironicbadger/nix-config/blob/main/flake.nix" target="_blank">github.com/ironicbadger/nix-config/flake.nix</a> that shows configuring macOS alongside nixOS in the same file.'
 {
   darwinConfigurations = {
     personal-laptop = darwinSystem "aarch64-darwin" "slartibartfast" "alex";

--- a/docs/02-tech-stack/os/linux.md
+++ b/docs/02-tech-stack/os/linux.md
@@ -2,7 +2,7 @@
 
 ![linux](../../images/logos/linux.jpg){: align=right width=300 }
 
-Ah, [Linux](https://linux.org). This game changing, pioneering, free and open source software is the foundation upon which everything that PMS is, is built.
+Ah, [Linux](https://www.linux.org). This game changing, pioneering, free and open source software is the foundation upon which everything that PMS is, is built.
 
 The project was founded in 1991 as a personal project by Linus Torvalds (hence the name Linux). Linux powers many of the worlds computers, is the basis of the Android kernel and is perhaps the ultimate unsung hero of modern computing times. Here is a full [history of Linux](https://en.wikipedia.org/wiki/History_of_Linux) if you're curious.
 

--- a/docs/02-tech-stack/proxmox.md
+++ b/docs/02-tech-stack/proxmox.md
@@ -48,4 +48,4 @@ ESXI by VMware is a juggernaut in the enterprise space but it comes with a steep
 
 However, ESXI is not open source. And for that simple fact, Proxmox is my goto recommendation for home users looking to virtualise all the things.
 
-[^1]: [How to Install OpenShift 4.6 using Terraform on VMware with UPI](https://www.openshift.com/blog/how-to-install-openshift-4.6-on-vmware-with-upi)
+[^1]: [How to Install OpenShift 4.6 using Terraform on VMware with UPI](https://www.redhat.com/en/blog/how-to-install-openshift-4.6-on-vmware-with-upi)

--- a/docs/02-tech-stack/zfs.md
+++ b/docs/02-tech-stack/zfs.md
@@ -68,7 +68,7 @@ Perhaps one day PMS will switch out to BTRFS but that day is a ways off yet - ZF
 ## Creating a storage pool
 
 !!! info
-    I originally wrote a [LinuxServer.io blog article on getting started with ZFS on Linux](https://blog.linuxserver.io/2019/05/14/getting-started-with-zfs-on-linux/).
+    I originally wrote a [LinuxServer.io blog article on getting started with ZFS on Linux](https://www.linuxserver.io/blog/2019-05-14-getting-started-with-zfs-on-linux).
 
 This article assumes you are using Ubuntu. We'll be creating a mirrored pair of drives for use with ZFS here. For reasons why you should use mirrors see [Jim's](https://jrs-s.net/2015/02/06/zfs-you-should-use-mirror-vdevs-not-raidz/) blog.
 
@@ -157,7 +157,7 @@ You must make sure you set `ashift` correctly. Disks often lie about their secto
 
 Scrubs are an important safety check to prevent bitrot. Ubuntu automatically schedules these for you.
 
-<blockquote class="twitter-tweet" align="center"><p lang="en" dir="ltr">New blog post about my new adventures with ZFS.<a href="https://t.co/gmGESknfL1">https://t.co/gmGESknfL1</a><br><br>Thanks <a href="https://twitter.com/allanjude?ref_src=twsrc%5Etfw">@allanjude</a> and <a href="https://twitter.com/jrssnet?ref_src=twsrc%5Etfw">@jrssnet</a> for the drive to actually, finally do this.</p>&mdash; Alex Kretzschmar (@IronicBadger) <a href="https://twitter.com/IronicBadger/status/1128326518046887938?ref_src=twsrc%5Etfw">May 14, 2019</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<blockquote class="twitter-tweet" align="center"><p lang="en" dir="ltr">New blog post about my new adventures with ZFS.<a href="https://www.linuxserver.io/blog/2019-05-14-getting-started-with-zfs-on-linux">https://www.linuxserver.io/blog/2019-05-14-getting-started-with-zfs-on-linux</a><br><br>Thanks <a href="https://twitter.com/allanjude?ref_src=twsrc%5Etfw">@allanjude</a> and <a href="https://twitter.com/jrssnet?ref_src=twsrc%5Etfw">@jrssnet</a> for the drive to actually, finally do this.</p>&mdash; Alex Kretzschmar (@IronicBadger) <a href="https://twitter.com/IronicBadger/status/1128326518046887938?ref_src=twsrc%5Etfw">May 14, 2019</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 View the status of a pools scrubs with `zpool status`.
 
@@ -189,7 +189,7 @@ One of the most compelling reasons to use ZFS is replication. We get more into t
 [^1]: [The Hidden Cost of ZFS for a Home NAS](https://louwrentius.com/the-hidden-cost-of-using-zfs-for-your-home-nas.html)
 [^2]: [Bonwick, Jeff (December 8, 2005) - "ZFS End-to-End Data Integrity"](https://en.wikipedia.org/wiki/ZFS#cite_note-endtoend-30)
 [^3]: [Checkums and Their Use in ZFS](https://openzfs.github.io/openzfs-docs/Basic%20Concepts/Checksums.html)
-[^4]: [DKMS - Arch Wiki](https://wiki.archlinux.org/index.php/Dynamic_Kernel_Module_Support)
+[^4]: [DKMS - Arch Wiki](https://wiki.archlinux.org/title/Dynamic_Kernel_Module_Support)
 [^5]: [Linus Torvalds ZFS Mailing List Rant](https://www.realworldtech.com/forum/?threadid=189711&curpostid=189841)
 [^6]: [Changes/BtrfsByDefault](https://fedoraproject.org/wiki/Changes/BtrfsByDefault)
 [^7]: [Jim Salter's Blog - ZFS category](https://jrs-s.net/category/open-source/zfs/)

--- a/docs/03-installation/manual-install-proxmox.md
+++ b/docs/03-installation/manual-install-proxmox.md
@@ -33,7 +33,7 @@ During installation, you will be prompted to create users, set your timezone, an
 
 Assuming a successful first boot to the Proxmox login TTY, log in as with your root username / password. Now we need to configure Proxmox repositories.
 
-By default, Proxmox ships with the enterprise repositories enabled and displays a subscription notice for unpaid installations. The excellent [Proxmox helper scripts](https://community-scripts.github.io/ProxmoxVE/scripts) make the initial configuration for our self-hosting purposes much easier.
+By default, Proxmox ships with the enterprise repositories enabled and displays a subscription notice for unpaid installations. The excellent [Proxmox helper scripts](https://community-scripts.org/scripts) make the initial configuration for our self-hosting purposes much easier.
 
 !!! info
     These scripts began as the work of [tteck](https://github.com/tteck/Proxmox), who sadly passed away in 2024. He left the community an excellent resource. Thanks, tteck. RIP.
@@ -320,7 +320,7 @@ These commands create the individual data disk mountpoints, the parity mountpoin
 
 Next, create entries in `/etc/fstab` so the disks mount automatically at boot.
 
-This file tells the OS which disks to mount, where to mount them, and which options to use. It can look complex, but each `fstab` entry breaks down to `<device> <mountpoint> <filesystem> <options> <dump> <fsck>`. See the [fstab documentation](https://wiki.archlinux.org/index.php/fstab) for more detail.
+This file tells the OS which disks to mount, where to mount them, and which options to use. It can look complex, but each `fstab` entry breaks down to `<device> <mountpoint> <filesystem> <options> <dump> <fsck>`. See the [fstab documentation](https://wiki.archlinux.org/title/Fstab) for more detail.
 
 !!! note
     mergerfs does _not_ mount the parity drive; it only mounts `/mnt/disk*`. mergerfs has _nothing to do_ with parity. SnapRAID handles that later.
@@ -538,7 +538,7 @@ services:
 
 You might have already created a user during Proxmox installation, if not, create one local, non-root user to own the files your containers and network shares write. This guide uses `ironicbadger` for that shared identity.
 
-The [LinuxServer.io](https://www.linuxserver.io/) team runs one of the most popular container projects on the web. Their [fleet](https://fleet.linuxserver.io/) of containers covers most apps a media server user is likely to need. They helped popularise `PUID` and `PGID` environment variables, which make container file permissions much easier to manage.
+The [LinuxServer.io](https://www.linuxserver.io/) team runs one of the most popular container projects on the web. Their [fleet](https://www.linuxserver.io/our-images) of containers covers most apps a media server user is likely to need. They helped popularise `PUID` and `PGID` environment variables, which make container file permissions much easier to manage.
 
 !!! success
     Make sure host volume directories are owned by the same user you specify in the container.
@@ -587,7 +587,7 @@ Start by configuring the server.
 
     If you want named users, auditability, or private folders, set `guest ok = no`, create Samba users with `smbpasswd`, remove the `force user` and `force group` lines if you want per-user file ownership, and restrict access with normal Linux ownership, groups, and permissions.
 
-As usual, the [Arch Wiki](https://wiki.archlinux.org/index.php/samba#Server) has a detailed entry on setting up and configuring a Samba server. Although PMS does not use Arch, much of the configuration guidance still applies.
+As usual, the [Arch Wiki](https://wiki.archlinux.org/title/Samba#Server) has a detailed entry on setting up and configuring a Samba server. Although PMS does not use Arch, much of the configuration guidance still applies.
 
 If you want the simplest way to get started with Samba, follow these steps.
 
@@ -691,7 +691,7 @@ After a client connects, you can view active Samba sessions on the server with `
 
 #### Samba client
 
-The [Arch Wiki](https://wiki.archlinux.org/index.php/samba#Client) also has useful client configuration notes. This section assumes you are mounting the share on a Linux CLI based system, such as a Raspberry Pi.
+The [Arch Wiki](https://wiki.archlinux.org/title/Samba#Client) also has useful client configuration notes. This section assumes you are mounting the share on a Linux CLI based system, such as a Raspberry Pi.
 
 * First, install the command-line SMB tools. `smbclient` lists and tests shares. `cifs-utils` is needed for mounting SMB shares through `/etc/fstab`.
 
@@ -726,7 +726,7 @@ Make sure the mountpoint exists. If it does not, create it with `mkdir /mnt/moun
 
 ### NFS
 
-Once again, the [Arch Wiki](https://wiki.archlinux.org/index.php/NFS#Installation) is the best place to go deeper on NFS. There is a lot of useful information in that article.
+Once again, the [Arch Wiki](https://wiki.archlinux.org/title/NFS#Installation) is the best place to go deeper on NFS. There is a lot of useful information in that article.
 
 NFS is less common for home media server use these days. Most users can get by happily with Samba alone. If you need NFS, you will probably know why.
 

--- a/docs/03-installation/manual-install-ubuntu.md
+++ b/docs/03-installation/manual-install-ubuntu.md
@@ -212,7 +212,7 @@ We also just created `/mnt/storage` in addition to our data disk mountpoints of 
 
 Next we need to create an entry in `/etc/fstab`.
 
-This file tells your OS how, where and which disks to mount. It looks a bit complex but an fstab entry is actually quite simple and breaks down to `<device> <mountpoint> <filesystem> <options> <dump> <fsck>` - [fstab documentation](https://wiki.archlinux.org/index.php/fstab).
+This file tells your OS how, where and which disks to mount. It looks a bit complex but an fstab entry is actually quite simple and breaks down to `<device> <mountpoint> <filesystem> <options> <dump> <fsck>` - [fstab documentation](https://wiki.archlinux.org/title/Fstab).
 
 !!! note
     Note that mergerfs does _not_ mount the parity drive, it only mounts `/mnt/disk*`. mergerfs has _nothing to do_ with parity, that is what we use SnapRAID for.
@@ -394,7 +394,7 @@ services:
 
 We need to find the user and group IDs for the user we plan to run our containers with. This is important because otherwise we will end up with file permissions errors.
 
-The [LinuxServer.io](https://www.linuxserver.io/) team are one of the most popular containerisation projects on the web. They provide a whole [fleet](https://fleet.linuxserver.io/) of containers that cater to pretty much every need the average Media Server enthusiast has. They pioneered a system of defining `PUID` and `PGID` in container environment variables to ensure permissions issues became a thing of the past.
+The [LinuxServer.io](https://www.linuxserver.io/) team are one of the most popular containerisation projects on the web. They provide a whole [fleet](https://www.linuxserver.io/our-images) of containers that cater to pretty much every need the average Media Server enthusiast has. They pioneered a system of defining `PUID` and `PGID` in container environment variables to ensure permissions issues became a thing of the past.
 
 !!! success
     Ensure any volume directories on the host are owned by the same user you specify and any permissions issues will vanish like magic.
@@ -427,7 +427,7 @@ Let's begin by configuring the server side of things.
 
 #### Samba server
 
-As is often the case the [Arch Wiki](https://wiki.archlinux.org/index.php/samba#Server) has a fantastically detailed entry on setting up and configuring a samba server. Despite the fact that PMS recommends Ubuntu, much of the configuration information provided by the Arch Wiki is valid for use by us.
+As is often the case the [Arch Wiki](https://wiki.archlinux.org/title/Samba#Server) has a fantastically detailed entry on setting up and configuring a samba server. Despite the fact that PMS recommends Ubuntu, much of the configuration information provided by the Arch Wiki is valid for use by us.
 
 If you just want the most brain dead simple way to get going with samba, here it is.
 
@@ -492,7 +492,7 @@ systemctl restart smbd
 
 #### Samba client
 
-Here's the relevant [Arch Wiki](https://wiki.archlinux.org/index.php/samba#Client) entry for configuring clients. This section assumes mounting is occuring on a Linux CLI based system (a Pi or something like that).
+Here's the relevant [Arch Wiki](https://wiki.archlinux.org/title/Samba#Client) entry for configuring clients. This section assumes mounting is occuring on a Linux CLI based system (a Pi or something like that).
 
 * First you'll need to install the samba client for your OS:
 
@@ -527,7 +527,7 @@ Ensure the mountpoint exists. If it doesn't, create it with `mkdir /mnt/mountpoi
 
 ### NFS
 
-Once again, the [Arch Wiki](https://wiki.archlinux.org/index.php/NFS#Installation) is the best place to dive _deep_ on NFS, and there really is a lot of great information in that article.
+Once again, the [Arch Wiki](https://wiki.archlinux.org/title/NFS#Installation) is the best place to dive _deep_ on NFS, and there really is a lot of great information in that article.
 
 There isn't much call for NFS these days for home use and we've found most users can get by with only samba quite happily. If you need NFS, you'll know it.
 

--- a/docs/03-installation/nixos-flake.md
+++ b/docs/03-installation/nixos-flake.md
@@ -1,3 +1,3 @@
 # NixOS Hard Mode - With Flakes
 
-See [ironicbadger/nix-testing](https://github.com/ironicbadger/nix-testing) for more.
+See [ironicbadger/nix-config](https://github.com/ironicbadger/nix-config) for more.

--- a/docs/04-day-two/backups.md
+++ b/docs/04-day-two/backups.md
@@ -17,7 +17,7 @@ The first copy is stored on a ZFS mirror, similar in concept to RAID 1. This kee
 !!! warning
     RAID of any form is NOT a backup! Only multiple physical copies following the 3-2-1 rule are a true backup. RAID is often incorrectly conflated with being a backup however it is designed to increase uptime not prevent data loss in and of itself.
 
-To mitigate these risks, it is considered good practice to store your most critical data offsite. Many options exist in this space such as [zfs.rent](https://zfs.rent), [backblaze](https://backblaze.com), [AWS Glacier](https://aws.amazon.com/s3/storage-classes/glacier/), and so on - do your research and pick which has a good privacy policy, encrypts your data and is affordable (watch out for those retrieval fees!).
+To mitigate these risks, it is considered good practice to store your most critical data offsite. Many options exist in this space such as [zfs.rent](https://zfs.rent), [backblaze](https://www.backblaze.com), [AWS Glacier](https://aws.amazon.com/s3/storage-classes/glacier/), and so on - do your research and pick which has a good privacy policy, encrypts your data and is affordable (watch out for those retrieval fees!).
 
 While many people use subscription-based services such as Google Drive or DropBox, the author has chosen to use backblaze.com due to its low cost. The author currently has approximately 250GB of data stored in Backblaze's B2 buckets at a cost of $0.005 GB/month, or approximately $1.25 per month. In the event that the worst were to happen and the author's disks were destroyed, it would cost approximately $2.50 to recover all of their most crucial files.
 

--- a/docs/04-day-two/remote-access/vpns.md
+++ b/docs/04-day-two/remote-access/vpns.md
@@ -12,7 +12,7 @@ WireGuard was first merged to the Linux kernel v5.6 in March 2020 [^1]. A relati
 
 ![tailscale-logo](../../images/logos/tailscale.png){: align=right width=20% }
 
-[Tailscale](https://tailscale.com/selfhosted/) is a mesh VPN that uses Wireguard under the hood. It works like an [overlay network](https://tailscale.com/blog/how-tailscale-works/) between the computers of your networks - using [NAT traversal](https://tailscale.com/blog/how-nat-traversal-works/).
+[Tailscale](https://tailscale.com/?utm_source=Self%20Hosted&utm_medium=paid-referral&utm_campaign=ad-read&utm_content=podcast) is a mesh VPN that uses Wireguard under the hood. It works like an [overlay network](https://tailscale.com/blog/how-tailscale-works) between the computers of your networks - using [NAT traversal](https://tailscale.com/blog/how-nat-traversal-works).
 
 Tailscale's control server works as an exchange point of Wireguard public keys for the nodes in the Tailscale network. It assigns the IP addresses of the clients, creates the boundaries between each user, enables sharing machines between users, and exposes the advertised routes of your nodes.
 

--- a/docs/04-day-two/top10apps.md
+++ b/docs/04-day-two/top10apps.md
@@ -26,11 +26,11 @@ It really is worth a look if you haven't tried it in a while. Client updates are
 <iframe src="https://player.fireside.fm/v2/dUlrHQih+B62wpyjN?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
 </p>
 
-[Plex](https://plex.tv) is the reason you're even reading this page. It's what got me interested in Linux in the first place and is somewhat of a gateway drug for self-hosting and can be run as a [container](https://hub.docker.com/r/plexinc/pms-docker/). However, it is not open source and the general posture of Plex as a company gives me pause. They continue to add features and streaming services that [no-one asked for](https://www.reddit.com/r/PleX/comments/e62nbt/how_do_you_disable_the_new_plex_movies_feature/) - [or wants](https://old.reddit.com/r/selfhosted/comments/zw4k2h/what_has_plex_done_lately_that_you_didnt_like/).
+[Plex](https://watch.plex.tv) is the reason you're even reading this page. It's what got me interested in Linux in the first place and is somewhat of a gateway drug for self-hosting and can be run as a [container](https://hub.docker.com/r/plexinc/pms-docker/). However, it is not open source and the general posture of Plex as a company gives me pause. They continue to add features and streaming services that [no-one asked for](https://www.reddit.com/r/PleX/comments/e62nbt/how_do_you_disable_the_new_plex_movies_feature/) - [or wants](https://old.reddit.com/r/selfhosted/comments/zw4k2h/what_has_plex_done_lately_that_you_didnt_like/).
 
 **Similar or related projects:**
 
-* [Plex](https://plex.tv)
+* [Plex](https://watch.plex.tv)
 * [Emby](https://emby.media/)
 * [Kodi](https://kodi.tv/)
 
@@ -68,11 +68,11 @@ Surely this pick needs no introduction. Think of Nextcloud somewhat like your ow
 
 It can be a bit unreliable and unwieldy to administer at times - especially around update cycles. But once you get a working configuration it's a really handy tool.
 
-[Nextcloud Hub](https://nextcloud.com/hub) brings together several key areas of functionality:
+[Nextcloud Hub](https://nextcloud.com/hub/) brings together several key areas of functionality:
 
-* [Nextcloud Files](https://nextcloud.com/files) - offers universal file access on desktop, mobile and web. Find files with powerful search, share your thoughts in comments or lock files until you are done with them.
-* [Nextcloud Talk](https://nextcloud.com/talk) - delivers on-premises, private audio/video conferencing and text chat through browser and mobile interfaces with integrated screen sharing and SIP integration.
-* [Nextcloud Groupware](https://nextcloud.com/groupware) - integrates Calendar, Contacts, Mail and other productivity features to help teams get their work done faster, easier and on your terms.
+* [Nextcloud Files](https://nextcloud.com/files/) - offers universal file access on desktop, mobile and web. Find files with powerful search, share your thoughts in comments or lock files until you are done with them.
+* [Nextcloud Talk](https://nextcloud.com/talk/) - delivers on-premises, private audio/video conferencing and text chat through browser and mobile interfaces with integrated screen sharing and SIP integration.
+* [Nextcloud Groupware](https://nextcloud.com/groupware/) - integrates Calendar, Contacts, Mail and other productivity features to help teams get their work done faster, easier and on your terms.
 
 **Similar or related projects:**
 
@@ -83,7 +83,7 @@ It can be a bit unreliable and unwieldy to administer at times - especially arou
 
 ![traefik-logo](../images/top10/traefik-logo.webp){: align=right width=200 }
 
-Yes, I know. A reverse proxy isn't the most terribly exciting inclusion in this list but it is one of the most important. [Traefik](https://traefik.io/traefik/) (pronounced "traffic") is my go-to reverse proxy. It can be configured alongside the containers it is proxying in the same [docker-compose](../02-tech-stack/docker-compose.md) yaml file.
+Yes, I know. A reverse proxy isn't the most terribly exciting inclusion in this list but it is one of the most important. [Traefik](https://traefik.io/traefik) (pronounced "traffic") is my go-to reverse proxy. It can be configured alongside the containers it is proxying in the same [docker-compose](../02-tech-stack/docker-compose.md) yaml file.
 
 Traefik does what any good reverse proxy should in 2025, it integrates with certbot and Let's Encrypt for automated TLS certificate generation for your service. Setup can be a bit complex at first but there's a complete [Traefik 101 guide](../04-day-two/remote-access/traefik101.md) over in the "remote access" section.
 
@@ -99,13 +99,13 @@ The elegance of configuring the ingress rules for a service in the same place as
 
 ![gitea-logo](../images/top10/gitea-logo.png){: align=left width=240 }
 
-A self-hosted, lightweight, yet highly feature rich git server, [Gitea](https://gitea.io) is much more powerful than it might seem at first. Sure, it has all the obivous trappings you'd expect from a code hosting solution such as multi-user support, organisations and a similar merge/fork model to a certain well-known online hub for Git activity.
+A self-hosted, lightweight, yet highly feature rich git server, [Gitea](https://about.gitea.com) is much more powerful than it might seem at first. Sure, it has all the obivous trappings you'd expect from a code hosting solution such as multi-user support, organisations and a similar merge/fork model to a certain well-known online hub for Git activity.
 
 As of [v1.19](https://blog.gitea.com/release-of-1.19.0/#-gitea-actions-21937) in March 2023 Gitea added Actions, a built-in CI system like GitHub Actions. With Gitea Actions, you can reuse your familiar workflows and Github Actions in your self-hosted Gitea instance.
 
 ![gitea](../images/top10/gitea-ui.png)
 
-One of my favourite features of Gitea is that it will automatically mirror remote git repositories locally when a commit is pushed. This makes it really easy to back up your code, and other people's code to your server - just in case. Because it's git the entire repo history is maintained and if for some reason a popular project became the target of a BS [DMCA claim](https://github.blog/2020-11-16-standing-up-for-developers-youtube-dl-is-back/), you're not up the creek without a paddle - so to speak.
+One of my favourite features of Gitea is that it will automatically mirror remote git repositories locally when a commit is pushed. This makes it really easy to back up your code, and other people's code to your server - just in case. Because it's git the entire repo history is maintained and if for some reason a popular project became the target of a BS [DMCA claim](https://github.blog/news-insights/policy-news-and-insights/standing-up-for-developers-youtube-dl-is-back/), you're not up the creek without a paddle - so to speak.
 
 Gitea doesn't have the kind of built-in CI features like the largest self-hosted and open source player in this space, Gitlab. But what it lacks in features it makes up for in small footprint and simplicity. These can instead be handled by external applications such as [drone](https://www.drone.io/). I wrote about deploying a site based on mkdocs (like this one) with drone CI [on my blog](https://blog.ktz.me/deploying-mkdocs-using-droneci/).
 
@@ -113,7 +113,7 @@ Gitea doesn't have the kind of built-in CI features like the largest self-hosted
 
 * [Forgejo](https://forgejo.org/faq/) - a recent fork of Gitea
 * [Gitlab](https://about.gitlab.com/)
-* [Gogs](https://gogs.io/)
+* [Gogs](https://gogs.io/getting-started/introduction)
 
 ## 7. Smokeping
 
@@ -167,11 +167,11 @@ There are a _lot_ of options in this space - just take a look at [awesome-selfho
 
 ## 10. Grafana
 
-[Grafana](https://grafana.com/) itself is graphing tool to display data stored elsewhere. It excels at displaying time-series data like the kind gathered by monitoring tools like [Telegraf](https://blog.linuxserver.io/2017/11/25/how-to-monitor-your-server-using-grafana-influxdb-and-telegraf/) and [Prometheus](https://prometheus.io/). It takes a bit of work to get a dashboard configured just the way you like it but is well worth the effort - after all, who doesn't like a pretty graph?
+[Grafana](https://grafana.com/) itself is graphing tool to display data stored elsewhere. It excels at displaying time-series data like the kind gathered by monitoring tools like [Telegraf](https://www.linuxserver.io/blog/2017-11-25-how-to-monitor-your-server-using-grafana-influxdb-and-telegraf) and [Prometheus](https://prometheus.io/). It takes a bit of work to get a dashboard configured just the way you like it but is well worth the effort - after all, who doesn't like a pretty graph?
 
 ![grafana](../images/top10/grafana.png)
 
-I've written previously about [monitoring your UPS](https://blog.linuxserver.io/2018/11/15/monitoring-a-ups-with-grafana-on-linux/) with Grafana to better keep track of the energy costs of your server setup.
+I've written previously about [monitoring your UPS](https://www.linuxserver.io/blog/2018-11-15-monitoring-a-ups-with-grafana-on-linux) with Grafana to better keep track of the energy costs of your server setup.
 
 ## 11. Surprise me...
 

--- a/docs/05-advanced/combine-zfs-and-others.md
+++ b/docs/05-advanced/combine-zfs-and-others.md
@@ -1,6 +1,6 @@
 # Combine ZFS with other filesystems using mergerfs
 
-The purpose of this post is to expand upon a concept I first introduced during the [Perfect Media Server - 2019 Edition](https://blog.linuxserver.io/2019/07/16/perfect-media-server-2019/). We'll cover why you might want to consider this approach in first place, how to layout your disks and discuss how this will provide you the ultimate flexibility if you don't want to fully commit to ZFS.
+The purpose of this post is to expand upon a concept I first introduced during the [Perfect Media Server - 2019 Edition](https://www.linuxserver.io/blog/2019-07-16-perfect-media-server-2019). We'll cover why you might want to consider this approach in first place, how to layout your disks and discuss how this will provide you the ultimate flexibility if you don't want to fully commit to ZFS.
 
 !!! info
     This post was originally published at [blog.ktz.me](https://blog.ktz.me/combining-zfs-with-other-filesystems-using-mergerfs/).

--- a/docs/05-advanced/passthrough-igpu-gvtg.md
+++ b/docs/05-advanced/passthrough-igpu-gvtg.md
@@ -17,7 +17,7 @@ What if you want to run Plex in a VM and take advantage of hardware accelerated 
 
 Passing through an entire GPU is very useful for specific tasks but isn't a very efficient use of resources. Wouldn't it be nice if we could slice up 1 GPU and use it with multiple VMs at once?
 
-That is precisely what [GVT-g](https://wiki.archlinux.org/index.php/Intel_GVT-g) permits us to do!
+That is precisely what [GVT-g](https://wiki.archlinux.org/title/Intel_GVT-g) permits us to do!
 
 Take the iGPU and give a VM, or multiple VMs, a slice of that graphics chip to do with whatever it wants. In our case, we'll use the Quick Sync portion of the iGPU to transcode Plex H264 streams in one VM and Blue Iris streams in another.
 

--- a/docs/06-hardware/cases.md
+++ b/docs/06-hardware/cases.md
@@ -68,7 +68,7 @@ The Fractal Define R5 is a classic example of "if it ain't broke, don't fix it".
 * PSU Form Factor - ATX
 * Number of 3.5" drive bays - 8
 * Dimensions - 23"D x 21.5"W x 13"H
-* Pricing - [$125-150](https://amzn.to/47FW8vd)
+* Pricing - [$125-150](https://www.amazon.com/Fractal-Design-Define-Gaming-FDCADEFR5BK/dp/B00Q2Z11QE)
 
 The case supports motherboards ranging from ITX to ATX in size. There's ample room for cable management with the high quality fit and finish that is a Fractal trademark at this point. The most remarkable thing about this case is how unremarkable it is, and I mean that in a good way. There's almost nothing not to like. It's a thoughtfully laid out and extremely well-built thing.
 
@@ -107,7 +107,7 @@ While this chassis is larger than other offerings, I chose it for its generous n
 
 ## Silverstone CS380
 
-> Review contributed by [glennbrown](http://github.com/glennbrown)
+> Review contributed by [glennbrown](https://github.com/glennbrown)
 
 The Silverstone CS380 was released in 2016 and is a great option for a Perfect Media Server. The case offers eight 3.5" hot swap bays plus two additional 5.25" bays.
 
@@ -167,7 +167,7 @@ When I was shopping for a case, I chose the Phantom 240 for the maximum amount o
 - **PSU Form Factor:** ATX
 - **Number of 3.5" Drive Bays:** 12
 - **Dimensions:** 18.5" x 16.92" x 8.07"
-- **Pricing:** Approximately $60 USD on [Newegg](https://www.newegg.com/p/2AM-02CE-000H9) / [eBay](https://www.ebay.com/sch/i.html?_&_nkw=Classico+Storage+Case)
+- **Pricing:** Approximately $60 USD on Newegg / [eBay](https://www.ebay.com/sch/i.html?_&_nkw=Classico+Storage+Case)
 
 This case, originally designed for Chia mining, proves to be an excellent option for storage and home server enthusiasts. Notably, it offers remarkable support for a substantial number of 3.5" HDDs, all at an affordable price point.
 
@@ -199,7 +199,7 @@ The Silverstone DS380B is available from the usual suspects and pops up on the s
 - Dimensions - 14 x 8.24 x 11.25" / 356 x 210 x 286 mm
 - Pricing:
     - Average used sale price on [eBay](https://www.ebay.com/sch/i.html?_from=R40&_trksid=p4432023.m570.l1313&_nkw=silverstone+DS380&_sacat=0) $180
-    - Typical new price on [Amazon](https://www.amazon.com/SilverStone-Technology-Mini-ITX-Computer-DS380B/dp/B00IAELTAI) or [Newegg](https://www.newegg.com/p/N82E16811163255) $215
+    - Typical new price on [Amazon](https://www.amazon.com/SilverStone-Technology-Mini-ITX-Computer-DS380B/dp/B00IAELTAI) or Newegg $215
 
 The DS380 offers a large number of easily interchangeable drives and a hot-swap backplane. This makes it compatible with a cold backup strategy or easy site-to-site transfer. Just ensure that you include a hot-swap-capable HBA in your build.
 

--- a/docs/06-hardware/hdd-purchase-methodology.md
+++ b/docs/06-hardware/hdd-purchase-methodology.md
@@ -1,7 +1,7 @@
 # Hard Disk Drive Purchasing Methodology
 
 !!! info
-    This is a snippet from the [2019 edition](https://blog.linuxserver.io/2019/07/16/perfect-media-server-2019/) of Perfect Media Server.
+    This is a snippet from the [2019 edition](https://www.linuxserver.io/blog/2019-07-16-perfect-media-server-2019) of Perfect Media Server.
 
 It is a fact of life that some mechanical hard drives are created more equal than others. The manufacturing tolerances involved are microscopic and transportation is a high risk time for any drive. For these reasons I try to follow some rules when purchasing drive(s).
 
@@ -42,7 +42,7 @@ I never even bothered trying to power that one up. It was returned immediately. 
 
 These rules happen to tie in nicely (surprise!) with some of my other overall thoughts on putting together the perfect media server and a topic I covered in the 2016 article. Namely, home users (the primary target for this series) probably don't want to have to buy 3+ drives at a time - it's just too much money to spend in one go! The ability to organically grow a system as your content collection, drone footage or linux ISO stash does is an absolutely core tenet and a key reason why I don't think any solution which requires adding more than one drive at once (going full ZFS, for example) is a suitable solution for most people, most of the time. By growing the system organically you not only put less pressure on your budget up front but you also potentially increase the overall reliability of the system thanks to Rule #1 and Rule #2.
 
-If you needed another reason; the longer you wait, the more TBs you'll get for the same cash. 2 years ago I tried to 'standardise' on 6TB drives. The time came 6 months ago when I wanted to add another drive to my system and for the same money per drive I could now furnish my system with an 8TB model. Backblaze, purveyors of the excellent ["Annual failure rate"](https://www.backblaze.com/b2/hard-drive-test-data.html) series, have [this interesting take](https://www.backblaze.com/blog/hard-drive-cost-per-gigabyte/) on cost per gigabyte.
+If you needed another reason; the longer you wait, the more TBs you'll get for the same cash. 2 years ago I tried to 'standardise' on 6TB drives. The time came 6 months ago when I wanted to add another drive to my system and for the same money per drive I could now furnish my system with an 8TB model. Backblaze, purveyors of the excellent ["Annual failure rate"](https://www.backblaze.com/cloud-storage/resources/hard-drive-test-data) series, have [this interesting take](https://www.backblaze.com/blog/hard-drive-cost-per-gigabyte/) on cost per gigabyte.
 
 The general takeaway from this is that you should never buy a hard drive because in 6 months you'll be able to get significantly more for your money. Of course, this is a reality of any tech. At some point you've just got to bite the bullet and press the purchase button - but you get my point, I hope.
 

--- a/docs/06-hardware/new-drive-burnin.md
+++ b/docs/06-hardware/new-drive-burnin.md
@@ -1,7 +1,7 @@
 That new hard drive. Should you trust it? Maybe.
 
 !!! info
-    The text of this article was originally published on [https://blog.linuxserver.io/2018/10/29/new-hard-drive-rituals/](https://blog.linuxserver.io/2018/10/29/new-hard-drive-rituals/).
+    The text of this article was originally published on [https://www.linuxserver.io/blog/2018-10-29-new-hard-drive-rituals](https://www.linuxserver.io/blog/2018-10-29-new-hard-drive-rituals).
 
 <p align="center">
 <figure markdown>

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,9 +48,9 @@ If you're looking to build a media server, then you've come to the right place. 
 !!! info "Perfect Media Server - A History"
     Perfect Media Server began life as a series of blog posts over at [blog.linuxserver.io](https://www.linuxserver.io/blog/tag:perfectmediaserver#blog_list):
 
-    - [Perfect Media Server (2016 Edition) - The Original Article](https://blog.linuxserver.io/2016/02/02/the-perfect-media-server-2016/)
-    - [Perfect Media Server (2017 Edition) - Extensive video guides](https://blog.linuxserver.io/2017/06/24/the-perfect-media-server-2017/)
-    - [Perfect Media Server (2019 Edition) - Boring is reliable + adding ZFS](https://blog.linuxserver.io/2019/07/16/perfect-media-server-2019/)
+    - [Perfect Media Server (2016 Edition) - The Original Article](https://www.linuxserver.io/blog/2016-02-02-the-perfect-media-server-2016)
+    - [Perfect Media Server (2017 Edition) - Extensive video guides](https://www.linuxserver.io/blog/2017-06-24-the-perfect-media-server-2017)
+    - [Perfect Media Server (2019 Edition) - Boring is reliable + adding ZFS](https://www.linuxserver.io/blog/2019-07-16-perfect-media-server-2019)
     - [Perfect Media Server (2020 Edition) - Launching perfectmediaserver.com](https://blog.ktz.me/the-perfect-media-server-2020-edition/)
 
 ## What is PMS? And what is this site for?
@@ -75,7 +75,7 @@ If you see a mistake, or think there's a hole in the content (why didn't you do 
 
 ## Self-Hosted podcast
 
-Lastly, if you like this kind of thing, check out the [Self-Hosted](https://selfhosted.show) podcast over at [Jupiter Broadcasting](https://jupiterbroadcasting.com) hosted by Alex and [Chris Fisher](https://twitter.com/ChrisLAS).
+Lastly, if you like this kind of thing, check out the [Self-Hosted](https://selfhosted.show) podcast over at [Jupiter Broadcasting](https://www.jupiterbroadcasting.com) hosted by Alex and [Chris Fisher](https://twitter.com/ChrisLAS).
 
 <iframe src="https://player.fireside.fm/v2/dUlrHQih+aGtGAbih?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
 

--- a/docs/jellyfinjune/index.md
+++ b/docs/jellyfinjune/index.md
@@ -5,7 +5,7 @@ JellyfinJune is a month-long KTZ Systems series about moving media serving back 
 The material here is intentionally practical: watch the episode, copy the useful bits, then adapt paths, domains, users, and hardware devices to your own Perfect Media Server.
 
 <p align="center">
-<iframe width="740" height="415" src="https://www.youtube.com/embed/videoseries?list=PLmaj94hXs3GFbjVg5UkdnpmO_HxCIMOXM&index=1" title="Jellyfin June playlist on YouTube" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="740" height="415" src="https://www.youtube.com/embed/videoseries?list=PLmaj94hXs3GFbjVg5UkdnpmO_HxCIMOXM" title="Jellyfin June playlist on YouTube" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </p>
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
Fixes #166

## Summary
- update redirected documentation links to their current destinations
- remove anti-bot Newegg product links while keeping the pricing references
- remove the stale YouTube playlist iframe index parameter

## Checks
- git diff --check
- verified updated URLs return 200 with a link-checker user agent (excluding links already excluded by the workflow)
- mkdocs build --strict

Note: I also attempted the Docker lychee command from the workflow, but Docker was not running in this environment.